### PR TITLE
NULL-134-secondary-tags

### DIFF
--- a/ai/for_save/query_extractor.py
+++ b/ai/for_save/query_extractor.py
@@ -1,12 +1,13 @@
 import logging
+from typing import Optional
 from dotenv import load_dotenv
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
 from langchain_core.prompts import PromptTemplate
-from langchain_core.documents.base import Document
 from langchain_core.runnables import RunnablePassthrough
-from langchain_core.output_parsers import StrOutputParser
-from vectorstores.tag_store import tag_store
-from models.add_memo import Res_memo, Res_add_memo
+from langchain_core.output_parsers import JsonOutputParser
+from pydantic import BaseModel, Field
+from ai.vectorstores.tag_store import tag_store, tag_collection, TAG_INDEX_NAME, TAG_CONTENT_NAME
+from models.add_memo import Res_add_memo, Res_memo_tag
 
 load_dotenv()
 
@@ -18,61 +19,166 @@ llm = ChatOpenAI(
 )
 
 vectorstore_for_tag=tag_store
-# one level extractor
-prompt=PromptTemplate.from_template("""
-You're an expert at analyzing and organizing sentences.
-Given a sentence, you pick a tag if it's strongly related to an existing tag, or create a new tag if you don't think it's relevant, to help organize the sentence.
-Tags are for big fields like economy and society.
-I'll tell you which country this sentence is used in, so you can categorize it in that country's context and generate tag in their language.
 
-I'll give you a sentence to analyze and a list of existing tags.
-Return only the tag name.
+class Tag(BaseModel):
+    name: str = Field(description="name of tag")
+    id: str = Field(description="id of tag")
 
-Country: Korea
-Sentence: {query}              
-List of tags: {tag_list}                       
-""")
+class Tag_list(BaseModel):
+    tags: list[Tag] = Field(description="list of tags")
+    def __getitem__(self, item):
+        return self.tags[item]
 
-def format_contexts(docs: list[Document]) -> str:
-    return ", ".join(f"{doc.page_content} (id: {doc.metadata['_id']['$oid']})" for doc in docs)
+def format_similar_tags(tags: list[dict[str, str]]) -> str:
+    return ", ".join(f"{tag['name']} (id: {tag['id']})" for tag in tags)
 
-retriever=vectorstore_for_tag.as_retriever(kwargs={"k": 10})
-one_level_chain=(
-    {
-        "query": RunnablePassthrough(),
-        "tag_list": retriever | format_contexts, # get the existing similar tags from db using embedding search
-    }
-    | prompt
-    | llm
-    | StrOutputParser()
-)
+def get_similar_tags(query: str, id: Optional[str]) -> list[dict[str, str]]:
+    similar_first_tags_res=tag_collection.aggregate([
+        {
+            "$vectorSearch": 
+            {
+                'index': TAG_INDEX_NAME,
+                'path': "embedding",
+                'queryVector': embeddings.embed_query(query),
+                'numCandidates': 500,
+                'limit': 10,
+            }
+        },
+        {
+            "$project": 
+            {
+                "_id": 1,
+                TAG_CONTENT_NAME: 1,
+                "parent": 1,
+            }
+        },
+        {
+            "$match": 
+            {
+                'parent': {'$eq': id }
+            }
+        }
+    ])
+
+    similar_first_tags: list[dict[str, str]]=[]
+    for res in similar_first_tags_res:
+        similar_first_tags.append({
+            "name": res[TAG_CONTENT_NAME],
+            "id": res["_id"]
+        })
+    
+    return similar_first_tags
+
+tags_output_parser=JsonOutputParser(pydantic_object=Tag_list)
+tags_format_instructions=tags_output_parser.get_format_instructions()
+
+def get_first_tags(query: str, formatted_tags: str) -> Tag_list:
+    first_tags_prompt=PromptTemplate.from_template(
+    """
+    You're an expert at analyzing and organizing sentences.
+    Given a sentence, you pick a few tags if it's strongly related to an existing tag, or create a new tag if you don't think it's relevant, to help organize the sentence.
+    Tags are for very big fields like economy and society.
+    I'll tell you which country this sentence is used in, so you can categorize it in that country's context and generate tag in their language.
+
+    I'll give you a sentence to analyze and a list of existing tags.
+
+    Country: Korea
+    Sentence: {query}              
+    List of tags: [{tag_list}]    
+
+    {format}
+    If you create a new tag, set the id to null.
+    """,
+    partial_variables={
+        "tag_list": formatted_tags,
+        "format": tags_format_instructions
+        }
+    )
+
+    first_tags_chain=(
+        { "query": RunnablePassthrough() }
+        | first_tags_prompt
+        | llm
+        | JsonOutputParser()
+    )
+    return first_tags_chain.invoke(query)
+
+def get_secondary_tags(query: str, first_tag: str, formatted_tags: str) -> Tag_list:
+    secondary_tags_prompt=PromptTemplate.from_template(
+    """
+    You're an expert at analyzing and organizing sentences.
+    You know that this sentence belongs to a specific domain, and you're categorizing it within that domain.
+    Given a sentence, you can choose a few tags from existing tags that is relevant to this sentence, or create a new tag.
+    Don't create tags with the same name as the domain.
+    
+    I'll tell you which country this sentence is used in, so you can categorize it in that country's context and generate tag in their language.
+    I'll give you a sentence to analyze, a list of existing tags, and the domain of sentence.
+
+    Country: Korea
+    Sentence: {query}              
+    List of tags: [{tag_list}]    
+    Domain: [{domain}]
+
+    {format}
+    If you create a new tag, set the id to null.
+    """,
+    partial_variables={
+        "tag_list": formatted_tags,
+        "format": tags_format_instructions,
+        "domain": first_tag
+        }
+    )
+
+    secondary_tags_chain=(
+        { "query": RunnablePassthrough() }
+        | secondary_tags_prompt
+        | llm
+        | JsonOutputParser()
+    )
+    return secondary_tags_chain.invoke(query)
 
 # returns existing tag id list, new tag list
-def query_extractor(query: str, country: str="Korea") -> tuple[list[str], list[Res_memo]]:
-    chain_res: str=one_level_chain.invoke(query)
-
-    logging.info(f'[QE] chain result: {chain_res} for "{query}"')
-
+def query_extractor(query: str, country: str="Korea") -> tuple[list[str], list[Res_memo_tag]]:
+    # return arguments
     existing_tag_ids: list[str]=[]
-    new_tags: list[Res_memo]=[]
+    new_tags: list[Res_memo_tag]=[]
 
-    # check whether the tag in the database
-    # TODO: use the database directly without embedding search
-    search_res: list[Document]=vectorstore_for_tag.similarity_search(chain_res, 1)
+    # get first tag(s)
+    similar_first_tags: list[dict[str, str]]=get_similar_tags(query, None)
+    formatted_similar_first_tags: str=format_similar_tags(similar_first_tags)
+    logging.info(f'[QE] similar first level tags: {formatted_similar_first_tags}')
 
-    # add a new tag
-    if len(search_res)==0 or search_res[0].page_content != chain_res:
-        insert_res: str=vectorstore_for_tag.add_texts([chain_res])[0] # get the new _id
-        logging.info(f'[QE] added new tag: {chain_res} / {insert_res} for "{query}"')
-        new_tags.append(Res_memo(
-            name=chain_res,
-            embedding=embeddings.embed_query(chain_res)
-        ))
+    first_tags: Tag_list=get_first_tags(query, formatted_similar_first_tags)
+    logging.info('f[QE] first level chain result: {first_tags}\nfor the query: "{query}"')
 
-    # use existing tag
-    else: 
-        found_res: list[str]
-        logging.info(f"[QE] found the tag: {search_res[0].page_content} / {search_res[0].metadata['_id']['$oid']} for '{query}'")
-        existing_tag_ids.append(search_res[0].metadata['_id']['$oid'])
+    # TODO: validation for tag ids
+    for first_tag in first_tags['tags']:
+        if first_tag['id'] is None: # if this tag is new
+            new_tags.append(Res_memo_tag(
+                name=first_tag['name'],
+                embedding=embeddings.embed_query(first_tag['name']),
+                parent="42", # ?
+            ))
+        else:
+            existing_tag_ids.append(first_tag['id'])
+
+    # TODO: parallelize this work
+    # for each first tag, find secondary tags
+    for first_tag in first_tags['tags']:
+        similar_secondary_tags: list[dict[str, str]]=get_similar_tags(query, first_tag['id'])
+        formatted_similar_secondary_tags: str=format_similar_tags(similar_first_tags)
+        secondary_tags: Tag_list=get_secondary_tags(query, first_tag['name'], formatted_similar_secondary_tags)
+        logging.info('f[QE] secondary level chain result: {secondary_tags}\nfor the tag: ({first_tag["name"]}, {first_tag["id"]})\nfor the query: "{query}"')
+
+        # TODO: validation for tag ids 
+        for secondary_tag in secondary_tags['tags']:
+            if secondary_tag['id'] is None:
+                new_tags.append(Res_memo_tag(
+                    name=secondary_tag['name'],
+                    embedding=embeddings.embed_query(secondary_tag['name']),
+                    parent=first_tag['id']
+                ))
+            else:
+                existing_tag_ids.append(secondary_tag['id'])
     
     return (existing_tag_ids, new_tags)

--- a/ai/for_save/query_extractor.py
+++ b/ai/for_save/query_extractor.py
@@ -169,7 +169,7 @@ def query_extractor(query: str, country: str="Korea") -> tuple[list[str], list[R
     # for each first tag, find secondary tags
     for first_tag in first_tags['tags']:
         similar_secondary_tags: list[dict[str, str]]=get_similar_tags(query, first_tag['id'])
-        formatted_similar_secondary_tags: str=format_similar_tags(similar_first_tags)
+        formatted_similar_secondary_tags: str=format_similar_tags(similar_secondary_tags)
         secondary_tags: Tag_list=get_secondary_tags(query, first_tag['name'], formatted_similar_secondary_tags)
         logging.info('f[QE] secondary level chain result: {secondary_tags}\nfor the tag: ({first_tag["name"]}, {first_tag["id"]})\nfor the query: "{query}"')
 

--- a/ai/for_save/query_extractor.py
+++ b/ai/for_save/query_extractor.py
@@ -8,6 +8,7 @@ from langchain_core.output_parsers import JsonOutputParser
 from pydantic import BaseModel, Field
 from ai.vectorstores.tag_store import tag_store, tag_collection, TAG_INDEX_NAME, TAG_CONTENT_NAME
 from models.add_memo import Res_add_memo, Res_memo_tag
+import random
 
 load_dotenv()
 
@@ -154,10 +155,12 @@ def query_extractor(query: str, country: str="Korea") -> tuple[list[str], list[R
     # TODO: validation for tag ids
     for first_tag in first_tags['tags']:
         if first_tag['id'] is None: # if this tag is new
+            first_tag['id']="temp_id"+str(random.randint(1, 2**64))
             new_tags.append(Res_memo_tag(
                 name=first_tag['name'],
                 embedding=embeddings.embed_query(first_tag['name']),
-                parent="42", # ?
+                parent=None,
+                id=first_tag['id'],
             ))
         else:
             existing_tag_ids.append(first_tag['id'])
@@ -176,7 +179,8 @@ def query_extractor(query: str, country: str="Korea") -> tuple[list[str], list[R
                 new_tags.append(Res_memo_tag(
                     name=secondary_tag['name'],
                     embedding=embeddings.embed_query(secondary_tag['name']),
-                    parent=first_tag['id']
+                    parent=first_tag['id'],
+                    id=None,
                 ))
             else:
                 existing_tag_ids.append(secondary_tag['id'])

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ async def search(body: Arg_search):
 @app.post("/add_memo/", response_model=Res_add_memo, status_code=status.HTTP_201_CREATED)
 async def add_memo(body: Arg_add_memo):
     existing_tag_ids: list[str]
-    new_tags: list[Res_memo]
+    new_tags: list[Res_memo_tag]
     existing_tag_ids, new_tags = qe.query_extractor(body.content)
 
     return Res_add_memo(

--- a/models/add_memo.py
+++ b/models/add_memo.py
@@ -1,13 +1,15 @@
 from pydantic import BaseModel
+from typing import Optional
 
 class Arg_add_memo(BaseModel):
     content: str
 
-class Res_memo(BaseModel):
+class Res_memo_tag(BaseModel):
     name: str
     embedding: list[float]
+    parent: Optional[str]
     
 class Res_add_memo(BaseModel):
     memo_embeddings: list[float]
     existing_tag_ids: list[str]
-    new_tags: list[Res_memo]
+    new_tags: list[Res_memo_tag]

--- a/models/add_memo.py
+++ b/models/add_memo.py
@@ -6,6 +6,7 @@ class Arg_add_memo(BaseModel):
 
 class Res_memo_tag(BaseModel):
     name: str
+    id: Optional[str]
     embedding: list[float]
     parent: Optional[str]
     


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

안녕하세요. 기다리고 기다리시던 2차태그 초안이 완성되었습니다.

# 💬 리뷰 중점사항

새 메모가 들어왔을 때, 해당 메모의 1차태그와 2차태그가 동시에 새로 만들어지면, 2차 태그의 parent에 뭘 넣어야 하는가 라는 문제가 생겼습니다.
일단 새로 생성된 1차 태그에 한해서
``` python
first_tag['id']="temp_id"+str(random.randint(1, 2**64))
``` 
처럼 임의의 id를 부여해주는 방식으로 해결해두긴 했는데, 다음에 얘기 ㄱ 

# 🖼 스크린샷 (선택)
