### PR TITLE
NULL-178 클라이언트에게 에러 정보를 제공하는 것에 관한

### DIFF
--- a/ai/for_search/query_analyzer.py
+++ b/ai/for_search/query_analyzer.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 import openai
 import logging
 from dotenv import load_dotenv
@@ -31,11 +32,12 @@ def query_analyzer(query: str) -> Query_Type:
         ],
     )
 
-    logging.info("[QA] analyzed query type: %s", res.choices[0].message.content)
+    logging.info("[QA] Analyzed query type: %s", res.choices[0].message.content)
 
     ret=res.choices[0].message.content
 
     if ret not in Query_Type._member_names_:
-        raise Exception("Failed to analyze the query. result:", ret)
+        logging.error("[QA] Invalid query type: %s", ret)
+        raise HTTPException(status_code=500, headers={"QA": "Failed to analyze the query."})
     
     return Query_Type(ret)

--- a/ai/for_search/regex_generator.py
+++ b/ai/for_search/regex_generator.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 import openai
 import os
 from dotenv import load_dotenv
@@ -34,6 +35,7 @@ def get_regex(q: str, country: str="korea") -> str:
     try:
         re.compile(ret) # check the returned regex
     except:
-        raise Exception("Failed to get regex. result:", ret)
+        logging.error("[RG] Failed regex validation: %s", ret)
+        raise HTTPException(status_code=500, headers={"RG": "Failed to get regex."})
     
     return ret

--- a/ai/for_search/tag_finder.py
+++ b/ai/for_search/tag_finder.py
@@ -1,4 +1,5 @@
 from dotenv import load_dotenv
+from fastapi import HTTPException
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
 from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnablePassthrough
@@ -48,7 +49,8 @@ def find_tag_ids(query: str) -> Optional[list[str]]:
     # TODO: improve this dumb way after change the db
     all_tags: list[Document]=vectorstore_for_tag.similarity_search("", k=1000)
     if any(tag_ids==str(tag.metadata['_id']['$oid']) for tag in all_tags) == False:
-        raise Exception("[TF] Failed to get tag ids. result:", tag_ids)
+        logging.error("[TF] Failed tag id validation: %s", tag_ids)
+        raise HTTPException(status_code=500, headers={"TF": "Failed to get tag id."})
     else:
         logging.info("[TF] Found the tags. result: [%s]", tag_ids)
         return [tag_ids]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 # from database import connection
 from typing import Optional
-from fastapi import FastAPI, status
+from fastapi import FastAPI, status, HTTPException
 from ai.for_search import query_analyzer as qa
 from ai.for_search import regex_generator as rg
 from ai.for_search import tag_finder as tf
@@ -25,24 +25,20 @@ async def default():
 async def search(body: Arg_search):
     return_content: Res_search=Res_search()
 
-    try:
-        return_content.type=qa.query_analyzer(body.content)
+    return_content.type=qa.query_analyzer(body.content)
 
-        if return_content.type == qa.Query_Type.regex:
-            return_content.regex=rg.get_regex(body.content)
-    
-        elif return_content.type == qa.Query_Type.tags:
-            return_content.tags=tf.find_tag_ids(body.content)
-            # if the tag search result is None
-            if return_content.tags == None:
-                # then trying similarity search
-                return_content.type = qa.Query_Type.similarity
-            
-        if return_content.type == qa.Query_Type.similarity:
-            return_content.processed_message, return_content.ids=ss.similarity_search(body.content)
-    except:
-        logging.error("[/search] %s", traceback.format_exc())
-        return_content.type=qa.Query_Type.unspecified
+    if return_content.type == qa.Query_Type.regex:
+        return_content.regex=rg.get_regex(body.content)
+
+    elif return_content.type == qa.Query_Type.tags:
+        return_content.tags=tf.find_tag_ids(body.content)
+        # if the tag search result is None
+        if return_content.tags == None:
+            # then trying similarity search
+            return_content.type = qa.Query_Type.similarity
+        
+    if return_content.type == qa.Query_Type.similarity:
+        return_content.processed_message, return_content.ids=ss.similarity_search(body.content)
 
     logging.info("[/search] query: %s / query type: %s \nreturn: %s", body.content, return_content.type, return_content)
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 나는 500에러 말고 뭔가 세분화된 뭔가가 있을 줄 알았는데 그냥 죄다 500으로 퉁치는 것 같음

2. 내부적으로 error와 info를 구별해서 로깅하도록 수정함

3. 이제 에러나면 어디서 에러났는지 정도는 클라이언트에서 확인 가능함

# 💬 리뷰 중점사항

1. 

# 🖼 스크린샷 (선택)
