### PR TITLE
NULL-274-kakao-parser-hotfix

### DIFF
--- a/ai/for_save/kakao_parser.py
+++ b/ai/for_save/kakao_parser.py
@@ -10,7 +10,9 @@ from typing import Optional
 
 def kakao_parser(content: str, type: kakao_parser_type) -> list[tuple[str, datetime]]:
     parsed_memolist: list[tuple[str, datetime]]
-
+    
+    content=content.replace("\ufeff", "")
+    
     if type == kakao_parser_type.CSV:
         csv_reader: csv.DictReader=_get_csv_reader_from_string(content)
         parsed_memolist: list[tuple[str, datetime]]=_parse_csv_reader(csv_reader)    
@@ -35,8 +37,11 @@ def _parse_csv_reader(reader: csv.DictReader) -> list[tuple[str, datetime]]:
         user="User"
         message="Message"
 
-    time_format="%Y.%m.%d %H:%M"
+    # time_format="%Y.%m.%d %H:%M"
+    time_format="%Y-%m-%d %H:%M:%S"
     for message in reader:
+        print(message)
+        
         content: str=message[_csv_field.message.value]
         date_str: str=message[_csv_field.date.value]
 

--- a/ai/for_save/kakao_parser.py
+++ b/ai/for_save/kakao_parser.py
@@ -40,8 +40,6 @@ def _parse_csv_reader(reader: csv.DictReader) -> list[tuple[str, datetime]]:
     # time_format="%Y.%m.%d %H:%M"
     time_format="%Y-%m-%d %H:%M:%S"
     for message in reader:
-        print(message)
-        
         content: str=message[_csv_field.message.value]
         date_str: str=message[_csv_field.date.value]
 

--- a/ai/for_save/single_adder.py
+++ b/ai/for_save/single_adder.py
@@ -11,6 +11,7 @@ def single_adder(memo: Arg_add_memo) -> Res_add_memo:
     existing_tag_ids, new_tags = qe.query_extractor(memo.content)
 
     return Res_add_memo(
+        content=memo.content,
         memo_embeddings=embeddings.embed_query(memo.content),
         existing_tag_ids=existing_tag_ids,
         new_tags=new_tags,

--- a/main.py
+++ b/main.py
@@ -65,14 +65,16 @@ async def get_embedding(body: Arg_get_embedding):
         embedding=qe.embeddings.embed_query(body.content)
     )
 
-@app.post("/kakao-parser/", response_model=list[Res_add_memo])
+@app.post("/kakao-parser/", response_model=Res_kakao_parser)
 async def kakao_parser(body: Arg_kakao_parser):
     parsed_memolist: list[tuple[str, datetime]]=kp.kakao_parser(body.content, body.type)
     memolist: list[Arg_add_memo]=[
         Arg_add_memo(content=content, timestamp=timestamp) for content, timestamp in parsed_memolist
     ]
     
-    return await ba.batch_adder(memolist)
+    return Res_kakao_parser(
+        kakao=await ba.batch_adder(memolist)
+    )
 
 if __name__ == '__main__':
     uvicorn.run(app)

--- a/models/add_memo.py
+++ b/models/add_memo.py
@@ -13,6 +13,7 @@ class Res_memo_tag(BaseModel):
     parent: Optional[str]
     
 class Res_add_memo(BaseModel):
+    content: str
     memo_embeddings: list[float]
     existing_tag_ids: list[str]
     new_tags: list[Res_memo_tag]

--- a/models/kakao_parser.py
+++ b/models/kakao_parser.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
-from datetime import datetime
 from enum import Enum
+from models.add_memo import Res_add_memo
 
 class kakao_parser_type(Enum):
     CSV="csv"
@@ -11,4 +11,4 @@ class Arg_kakao_parser(BaseModel):
     content: str
 
 class Res_kakao_parser(BaseModel):
-    parsed_memolist: list[tuple[str, datetime]]
+    kakao: list[Res_add_memo]


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. \ufeff 라는 encoding prefix가 붙어 들어와서 터지는 오류를 수정함
2. 시간 형식이 다른걸 수정함..
3. 메모를 만들 때 그 결과에 메모의 내용이 같이 들어감
4. kakao-parser의 response 배열에 이름이 없었는데 이름이 붙음

# 💬 리뷰 중점사항

1. 

# 🖼 스크린샷 (선택)
