### PR TITLE
NULL-330-hotfix fixed: prompt for tag extracting

### DIFF
--- a/ai/saving/tag/extractor/chains/existing_tag.py
+++ b/ai/saving/tag/extractor/chains/existing_tag.py
@@ -19,7 +19,8 @@ _existing_chain_prompt=PromptTemplate.from_template(
     Given a document, you choose the best categorization you think fits.
     Choose based on how the average person categorizes notes.
     You might not choose one if you don't think it's a good fit, or you might choose multiple if you think there are several that are very good fits.
-
+    If such a category does not exist, you don't have to select it.
+    
     I've attached the document and the categorizations for you.
 
     Language: {lang}

--- a/main.py
+++ b/main.py
@@ -21,8 +21,8 @@ from models.kakao_parser import *
 
 app = FastAPI(
     title="Oatnote AI",
-    description="after PR #40, changed genarate tag algorithm",
-    version="0.1.4",
+    description="after PR #44, changed genarate tag algorithm",
+    version="0.1.6",
 )
 init(app)
     


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 기존에 태그가 존재하지 않을 때 기존 태그중에 적합한 태그를 고르는 과정에서 터지더라고요
디비 안 날리고 테스트해본 내 탓이다 ㅋㅋ

# 💬 리뷰 중점사항

1. 

# 🖼 스크린샷 (선택)
