### PR TITLE
NULL-373-unique-tag-validation

### DIFF
--- a/srcs/ai/saving/structure/utils/locator/chains/get_new_relations_and_tags_chain.py
+++ b/srcs/ai/saving/structure/utils/locator/chains/get_new_relations_and_tags_chain.py
@@ -21,6 +21,7 @@ You can use the directory's metadata to categorize it correctly.
 
 In addition to putting new directories into existing directories, you can also create new directories of your own.
 For example, if you have an existing directory called 'plants' and you need to organize the directory 'apples', you can create a new relationship 'plants'-'apples', but also create a new directory called 'fruits', such as 'plants'-'fruits', 'fruits'-'apples', etc.
+However, do not create a new tag with the same name as an existing tag.
 If you created a new directory, make sure the name and ID of that directory are exactly the same.
 
 I'm attaching the existing directory structure.

--- a/srcs/ai/saving/tag/utils/selector/tag_selector.py
+++ b/srcs/ai/saving/tag/utils/selector/tag_selector.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import logging
 from ai.saving._models import Tag
 from ai.saving.tag.utils.selector.chains import tag_selector_chain
@@ -5,6 +6,23 @@ from ai.saving.tag.utils.selector.chains import tag_selector_chain
 
 async def select_tags(query: str, tag_list: list[Tag], lang: str="Korean") -> list[Tag]:
     chain_result=await tag_selector_chain.ainvoke({"query": query, "tag_list": tag_list, "lang": lang})
-    logging.info("[select_tags]\n## selected tags:\n%s\n\n", chain_result)
+    uniqued_tags: list[Tag]=_get_uniqued_tags(chain_result.tag_list)
+    logging.info("[select_tags]\n## selected tags:\n%s\n\n", uniqued_tags)
+    
+    return uniqued_tags
 
-    return chain_result.tag_list
+def _get_uniqued_tags(tags: list[Tag]) -> list[Tag]:
+    tag_dict=defaultdict(list[Tag])
+    
+    for tag in tags:
+        tag_dict[tag.name].append(tag)
+    
+    uniqued_tags: list[Tag]=[]
+    for name, tags in tag_dict.items():
+        merged=tags[0]
+        for tag in tags:
+            if tag.id != tag.name: 
+                merged.id=tag.id
+        uniqued_tags.append(merged)
+    
+    return uniqued_tags

--- a/srcs/main.py
+++ b/srcs/main.py
@@ -12,8 +12,8 @@ from ai.saving.structure import process_memos, get_structure
 
 app = FastAPI(
     title="Oatnote AI",
-    description="after PR #70, https://github.com/swm-null/null_null/pull/70",
-    version="0.2.19",
+    description="after PR #71, https://github.com/swm-null/null_null/pull/71",
+    version="0.2.20",
 )
 init(app)
     


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 태그 추출할 때 기존에 존재하는 태그 이름이 중복되어 생성되지 않도록 조치함
2. 태그 배치할 때 똑같이 조치함
3. 여기 말곤 뭐 없겠지 생각해봐도 없는 것 같어
4. 혹시라도 태그 이름 중복되는 일이 있으면 바로 말해주세요.

# 💬 리뷰 중점사항

1. 

# 🖼 스크린샷 (선택)
