### PR TITLE
NULL-437-hotfix-tag-id

### DIFF
--- a/srcs/ai/saving/structure/utils/__init__.py
+++ b/srcs/ai/saving/structure/utils/__init__.py
@@ -3,3 +3,4 @@ from ai.saving.structure.utils.memo_and_tags_converter import convert_memos_and_
 from ai.saving.structure.utils.tag_converter import convert_tag
 from ai.saving.structure.utils.relations_converter import convert_relations
 from ai.saving.structure.utils.metadata_extractor.metadata_extractor import extract_and_assign_metadata
+from ai.saving.structure.utils.get_tag_name_to_id_dict import get_tag_name_to_id_dict

--- a/srcs/ai/saving/structure/utils/directory_format.py
+++ b/srcs/ai/saving/structure/utils/directory_format.py
@@ -23,7 +23,7 @@ def _get_tags_from_db(user_id: str) -> tuple[dict[str, str], dict[str, str]]:
     return id_to_name, name_to_id
     
 def _format_graph(graph: dict[str, list[str]], tag_id_to_name: dict[str, str], now_id: str, depth: int=1) -> str:
-    result: str=f'{tag_id_to_name[now_id]} ({now_id})\n'
+    result: str=f'{tag_id_to_name[now_id]}\n'
     next_ids: list[str]=_get_next_ids_from_graph(graph, now_id)
     
     for next_id in next_ids:

--- a/srcs/ai/saving/structure/utils/get_tag_name_to_id_dict.py
+++ b/srcs/ai/saving/structure/utils/get_tag_name_to_id_dict.py
@@ -1,0 +1,8 @@
+from ai.saving.structure.utils.directory_format import _get_tags_from_db
+
+
+def get_tag_name_to_id_dict(user_id: str) -> dict[str, str]:
+    tag_id_to_name, tag_name_to_id=_get_tags_from_db(user_id)
+    
+    return tag_name_to_id
+    

--- a/srcs/ai/saving/structure/utils/locator/chains/get_new_relations_and_tags_chain.py
+++ b/srcs/ai/saving/structure/utils/locator/chains/get_new_relations_and_tags_chain.py
@@ -1,13 +1,15 @@
 from operator import itemgetter
 from langchain_core.output_parsers import PydanticOutputParser
 from pydantic import BaseModel, Field
-from ai.saving.structure._models.directory_relation import Directory_relation
 from ai.utils.llm import llm4o
 from langchain_core.prompts import PromptTemplate
 
+class Relation_for_chain(BaseModel):
+    parent_name: str
+    child_name: str
 
 class Get_new_relations_and_tags_chain_output(BaseModel):
-    relations: list[Directory_relation]=Field(description="relations of new directory")
+    relations: list[Relation_for_chain]=Field(description="relations of new directory")
     new_directories: list[str]=Field(description="name of given directories or a newly created directory")
 
 _parser = PydanticOutputParser(pydantic_object=Get_new_relations_and_tags_chain_output)
@@ -21,12 +23,10 @@ You can use the directory's metadata to categorize it correctly.
 
 In addition to putting new directories into existing directories, you can also create new directories of your own.
 For example, if you have an existing directory called 'plants' and you need to organize the directory 'apples', you can create a new relationship 'plants'-'apples', but also create a new directory called 'fruits', such as 'plants'-'fruits', 'fruits'-'apples', etc.
-However, do not create a new tag with the same name as an existing tag.
-If you created a new directory, make sure the name and ID of that directory are exactly the same.
+However, do not create a new tag with the same name as an existing tag. 
 
 I'm attaching the existing directory structure.
 The directory with the name '@' is the root.
-A string next to the name is the directory's id.
 When the number of '-'s increases, it means you're inside that directory.
 Write the directory's name in the user's language.
 

--- a/srcs/ai/saving/structure/utils/locator/tag_locator.py
+++ b/srcs/ai/saving/structure/utils/locator/tag_locator.py
@@ -1,28 +1,34 @@
+import logging
 import uuid
 from ai.saving._models import Tag
 from ai.saving.structure._models.directory_relation import Directory_relation
 from ai.saving.structure.utils.directory_format import get_formatted_directories
 from ai.saving.structure.utils.locator.chains import get_new_relations_and_tags_chain
+from ai.saving.structure.utils.locator.chains.get_new_relations_and_tags_chain import Relation_for_chain
 from ai.saving.structure.utils.locator.chains.get_new_relations_and_tags_chain import get_new_relations_and_tags_chain, Get_new_relations_and_tags_chain_output
 from ai.saving.structure._models.memo import Memo
+from ai.saving.structure.utils.get_tag_name_to_id_dict import get_tag_name_to_id_dict
 
 
 def locate_tags(user_id: str, tags: list[Tag], memos: dict[int, Memo], lang: str) -> tuple[list[Directory_relation], list[Tag]]:
     formatted_directories: str=get_formatted_directories(user_id)
-    new_dir_relations, new_tags=_get_new_relations_and_tags(tags, memos, lang, formatted_directories)
+    tag_name_to_id: dict=get_tag_name_to_id_dict(user_id)
+    new_dir_relations, new_tags=_get_new_relations_and_tags(tags, memos, lang, formatted_directories, tag_name_to_id)
+    logging.info("[locate_tags]\n## new_dir_relations:\n%s\n\n## new tags:\n%s\n\n", new_dir_relations, new_tags)
     
     return new_dir_relations, new_tags
 
 def _format_tags(tags: list[Tag]) -> str:
-    return ", ".join(f"{tag.name} for memo {tag.connected_memo_id}" for tag in tags)
+    return ", ".join(f"\"{tag.name}\" for memo {tag.connected_memo_id}" for tag in tags)
 
 def _format_metadatas(memos: dict[int, Memo]) -> str:
-    return "".join(f"\nmemo {id}: {memo.metadata}" for id, memo in memos.items())
+    return "".join(f"\nmemo {id}: \"{memo.metadata}\"" for id, memo in memos.items())
     
-def _get_new_relations_and_tags(tags: list[Tag], memos: dict[int, Memo], lang:str, directories: str) -> tuple[list[Directory_relation], list[Tag]]:
+def _get_new_relations_and_tags(tags: list[Tag], memos: dict[int, Memo], lang:str, directories: str, tag_name_to_id: dict[str, str]) -> tuple[list[Directory_relation], list[Tag]]:
     chain_result: Get_new_relations_and_tags_chain_output=get_new_relations_and_tags_chain.invoke({"tags": _format_tags(tags), "metadatas": _format_metadatas(memos), "lang": lang, "directories": directories})
     tag_name_to_tag: dict[str, Tag]=_assign_id_to_new_tags(chain_result.new_directories)
-    modified_relations: list[Directory_relation]=_modify_id_on_new_relations(chain_result.relations, tag_name_to_tag)
+    merged_tag_name_to_id: dict[str, str]=_merge_new_tag_ids_and_existing_tag_ids(tag_name_to_tag, tag_name_to_id)
+    modified_relations: list[Directory_relation]=_modify_id_on_new_relations(chain_result.relations, merged_tag_name_to_id)
     
     return modified_relations, [*tag_name_to_tag.values()]
 
@@ -38,13 +44,22 @@ def _assign_id_to_new_tags(tag_names: list[str]) -> dict[str, Tag]:
     
     return tag_name_to_tag
 
-def _modify_id_on_new_relations(relations: list[Directory_relation], tag_name_to_tag: dict[str, Tag]) -> list[Directory_relation]:
+def _merge_new_tag_ids_and_existing_tag_ids(new_tags: dict[str, Tag], existing_tag_name_to_id: dict[str, str]) -> dict[str, str]:
+    merged: dict[str, str]={}
+    
+    for new_tag in new_tags.values():
+        merged[new_tag.name]=new_tag.id
+    merged.update(existing_tag_name_to_id)
+    
+    return merged
+
+def _modify_id_on_new_relations(relations: list[Relation_for_chain], tag_name_to_id: dict[str, str]) -> list[Directory_relation]:
     return [
         Directory_relation(
             parent_name=relation.parent_name,
-            parent_id=tag_name_to_tag[relation.parent_name].id if relation.parent_id in tag_name_to_tag else relation.parent_id,
+            parent_id=tag_name_to_id[relation.parent_name],
             child_name=relation.child_name,
-            child_id=tag_name_to_tag[relation.child_name].id if relation.child_id in tag_name_to_tag else relation.child_id,
+            child_id=tag_name_to_id[relation.child_name],
         ) for relation in relations
     ]
     

--- a/srcs/main.py
+++ b/srcs/main.py
@@ -12,8 +12,8 @@ from ai.saving.structure import process_memos, get_structure
 
 app = FastAPI(
     title="Oatnote AI",
-    description="after PR #73, https://github.com/swm-null/null_null/pull/73",
-    version="0.2.22",
+    description="after PR #74, https://github.com/swm-null/null_null/pull/74",
+    version="0.2.23",
 )
 init(app)
     


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. llm이 태그 id를 자꾸 이상하게 지멋대로 만들어서 쓰는 문제가 있어서. 이제 우리는 태그 아이디가 unique하니까 이걸 id 대신 쓸 수 있단 말임? 그래서 아예 id 자체를 프롬프트에서 빼고 태그 이름가지고 id를 내가 직접 넣음
2. 최근 문제 90%가 이거때문에 프롬프트 조금 고쳐넣고 그랬는데 계속 터져서. 근본적인 문제를 해결했으니 다시 안 터지지 않을까?


# 💬 리뷰 중점사항

1. 

# 🖼 스크린샷 (선택)
