### PR TITLE
NULL-439-remove-similar-tag-name + NULL-440

### DIFF
--- a/srcs/ai/saving/tag/utils/extractor/chains/existing_tag.py
+++ b/srcs/ai/saving/tag/utils/extractor/chains/existing_tag.py
@@ -9,7 +9,7 @@ from langchain_core.prompts import PromptTemplate
 
 
 class _existing_tag_output(BaseModel):
-    tag_list: list[Tag]=Field(description="list of tags")
+    tag_list: list[str]=Field(description="list of tag names")
 
 _parser = PydanticOutputParser(pydantic_object=_existing_tag_output)
 
@@ -26,7 +26,7 @@ The document is given between ᝃ. Sometimes it can be empty.
 
 Language: {lang}
 Document: ᝃ{query}ᝃ
-List of categories: [{tag_list}]
+List of categories: [{tag_names}]
 
 {format}
 """,
@@ -39,7 +39,7 @@ existing_tag_chain=(
     {
         "query": itemgetter("query"),
         "lang": itemgetter("lang"),
-        "tag_list": itemgetter("query", "user_id") | RunnableLambda(lambda args: retrieve_similar_tags(args[0], args[1])), # type: ignore
+        "tag_names": itemgetter("tag_names")
     }
     | _existing_chain_prompt
     | llm4o

--- a/srcs/ai/saving/tag/utils/extractor/chains/new_tag.py
+++ b/srcs/ai/saving/tag/utils/extractor/chains/new_tag.py
@@ -1,19 +1,22 @@
 from operator import itemgetter
 from langchain_core.output_parsers import PydanticOutputParser
-from ai.saving._models import Tag
+from pydantic import BaseModel
 from ai.utils import llm4o
 from langchain_core.prompts import PromptTemplate
 
+class _Tag_name(BaseModel):
+    name: str
 
-_parser = PydanticOutputParser(pydantic_object=Tag)
+_parser = PydanticOutputParser(pydantic_object=_Tag_name)
 
-_new_chain_prompt=PromptTemplate.from_template(
+_new_tag_chain_prompt=PromptTemplate.from_template(
 """
 You're an expert at categorizing documents.
 Given a document, you create a category to encompass it.
 Create based on how the average person categorizes notes.
 Not just a category for this document, but a category for anything similar to this document. 
 But I don't want the category to be so broad that it could contain too many documents.
+Use ' ' and do not use '_'.
 
 I'm attaching a document for you.
 Create the category in the user's language.
@@ -24,7 +27,6 @@ User's language: {lang}
 Document: ᝃ{query}ᝃ
 
 {format}
-Set new category's id to category's name.
 """,
     partial_variables={
         "format": _parser.get_format_instructions()
@@ -36,7 +38,7 @@ new_tag_chain=(
         "query": itemgetter("query"),
         "lang": itemgetter("lang"),
     }
-    | _new_chain_prompt
+    | _new_tag_chain_prompt
     | llm4o
     | _parser
 )

--- a/srcs/ai/saving/tag/utils/extractor/similar_tags_retriever.py
+++ b/srcs/ai/saving/tag/utils/extractor/similar_tags_retriever.py
@@ -1,13 +1,12 @@
-from ai.saving.tag.utils.tag_formatter import format_tags
 from ai.utils.embedder import embedder
 from ai.database.collections.tag_store import TAG_CONTENT_NAME, TAG_ID_NAME, TAG_INDEX_NAME, TAG_UID_NAME, tag_collection
 from ai.saving._models import Tag
 
 
-def retrieve_similar_tags(query: str, user_id: str) -> str:
+def retrieve_similar_tags(query: str, user_id: str) -> list[Tag]:
     tag_list: list[Tag]=_get_similar_tags_from_db(query, user_id)
-    formatted_tag_list=format_tags(tag_list)
-    return formatted_tag_list
+    
+    return tag_list
 
 def _get_similar_tags_from_db(query: str, user_id: str) -> list[Tag]: 
     raw_tags=tag_collection.find({TAG_UID_NAME: user_id})

--- a/srcs/ai/saving/tag/utils/extractor/tag_extractor.py
+++ b/srcs/ai/saving/tag/utils/extractor/tag_extractor.py
@@ -2,18 +2,39 @@ import asyncio
 import logging
 from langchain_core.runnables import RunnableParallel
 from ai.saving.tag.utils.extractor.chains import existing_tag_chain, new_tag_chain
+from ai.saving.tag.utils.extractor.similar_tags_retriever import retrieve_similar_tags
+from ai.saving.tag.utils.tag_formatter import format_tags
 from ai.saving._models import Tag
 
 
 async def extract_tags(query: str, user_id: str, lang: str="Korean") -> list[Tag]:
+    similar_tags: list[Tag]=retrieve_similar_tags(query, user_id)
     chain=RunnableParallel(existing=existing_tag_chain, new=new_tag_chain)
-    chain_result=await asyncio.to_thread(chain.invoke, {"query": query, "lang": lang, "user_id": user_id})
-    logging.info("[extract_tags]\n## existing tags:\n%s\n\n## new tags:\n%s\n\n", chain_result["existing"].tag_list, chain_result["new"])
+    chain_result=await asyncio.to_thread(chain.invoke, {"query": query, "lang": lang, "user_id": user_id, "tag_names": format_tags(similar_tags)})
+    logging.info("[extract_tags]\n## existing tags:\n%s\n\n## new tags:\n%s\n\n", chain_result["existing"].tag_list, chain_result["new"].name)
     
-    extracted_tag: list[Tag]=[]
+    extracted_tags: list[Tag]=[]
+    extracted_tags.extend(_convert_existing_chain_result(chain_result["existing"].tag_list, similar_tags))
+    extracted_tags.extend(_convert_new_chain_result(chain_result["new"].name))
     
-    extracted_tag.extend(chain_result["existing"].tag_list)
-    if not any(exist_tag.name == chain_result["new"].name for exist_tag in chain_result["existing"].tag_list): 
-        extracted_tag.append(chain_result["new"]) # this tag's id should be tag's name
+    return extracted_tags
+
+def _convert_existing_chain_result(selected_tag_names: list[str], tags: list[Tag]) -> list[Tag]:
+    return [
+        Tag(
+            id=tag.id,
+            name=tag.name,
+            is_new=False
+        )
+        for tag in tags if tag.name in selected_tag_names
+    ]
     
-    return extracted_tag
+
+def _convert_new_chain_result(tag_name: str) -> list[Tag]:
+    return [
+        Tag(
+            id=tag_name, 
+            name=tag_name, 
+            is_new=True
+        )
+    ]

--- a/srcs/ai/saving/tag/utils/selector/chains/tag_selector_chain.py
+++ b/srcs/ai/saving/tag/utils/selector/chains/tag_selector_chain.py
@@ -2,15 +2,14 @@ from operator import itemgetter
 from langchain_core.runnables import RunnableLambda
 from langchain_core.output_parsers import PydanticOutputParser
 from pydantic import BaseModel, Field
-from ai.saving._models import Tag
-from ai.saving.tag.utils.tag_formatter import format_tags
 from ai.utils.llm import llm4o
 from langchain_core.prompts import PromptTemplate
 from ai.saving.tag._configs import TAG_SELECTION_COUNT
+from ai.saving.tag.utils.selector.chains.utils.tag_formater_with_is_new import format_tags_with_is_new
 
 
 class _selected_tag_output(BaseModel):
-    tag_list: list[Tag] = Field(description="list of tags")
+    tag_names: list[str] = Field(description="selected tag names")
 
 _parser = PydanticOutputParser(pydantic_object=_selected_tag_output)
 
@@ -27,7 +26,7 @@ The document is given between ᝃ. Sometimes it can be empty.
 
 Language: {lang}
 Document: ᝃ{query}ᝃ
-List of categories: [{tag_list}]
+List of categories: [{tags}]
 
 {format}
 """,
@@ -40,7 +39,7 @@ List of categories: [{tag_list}]
 tag_selector_chain=(
     {
         "query": itemgetter("query"),
-        "tag_list": itemgetter("tag_list") | RunnableLambda(format_tags),
+        "tags": itemgetter("tags") | RunnableLambda(format_tags_with_is_new),
         "lang": itemgetter("lang"),
     }
     | _tag_selector_chain_prompt

--- a/srcs/ai/saving/tag/utils/selector/chains/tag_selector_chain.py
+++ b/srcs/ai/saving/tag/utils/selector/chains/tag_selector_chain.py
@@ -20,6 +20,7 @@ You're an expert at categorizing documents.
 Given a document and a set of categories, you choose which category this document can belong to.
 Pick up to '{selection_count}' of the most relevant categories that this article could belong to.
 You don't have to select all {selection_count} categories if you think they are less relevant.
+Dismiss new tags that is very similar to existing tag like "짧은 질문" and "짧은질문".
 
 I'll attach the document and the categories for you.
 The document is given between ᝃ. Sometimes it can be empty.

--- a/srcs/ai/saving/tag/utils/selector/chains/utils/tag_formater_with_is_new.py
+++ b/srcs/ai/saving/tag/utils/selector/chains/utils/tag_formater_with_is_new.py
@@ -1,0 +1,5 @@
+from ai.saving._models.tag import Tag
+
+
+def format_tags_with_is_new(tags: list[Tag]) -> str:
+    return ", ".join(f"\"{tag.name}\" (new: {tag.is_new})" for tag in tags)

--- a/srcs/ai/saving/tag/utils/selector/tag_selector.py
+++ b/srcs/ai/saving/tag/utils/selector/tag_selector.py
@@ -4,25 +4,14 @@ from ai.saving._models import Tag
 from ai.saving.tag.utils.selector.chains import tag_selector_chain
 
 
-async def select_tags(query: str, tag_list: list[Tag], lang: str="Korean") -> list[Tag]:
-    chain_result=await tag_selector_chain.ainvoke({"query": query, "tag_list": tag_list, "lang": lang})
-    uniqued_tags: list[Tag]=_get_uniqued_tags(chain_result.tag_list)
+async def select_tags(query: str, tags: list[Tag], lang: str="Korean") -> list[Tag]:
+    chain_result=await tag_selector_chain.ainvoke({"query": query, "tags": tags, "lang": lang})
+    uniqued_tags: list[Tag]=_get_uniqued_tags(chain_result.tag_names, tags)
     logging.info("[select_tags]\n## selected tags:\n%s\n\n", uniqued_tags)
     
     return uniqued_tags
 
-def _get_uniqued_tags(tags: list[Tag]) -> list[Tag]:
-    tag_dict=defaultdict(list[Tag])
+def _get_uniqued_tags(selected_tag_names: list[str], tags: list[Tag]) -> list[Tag]:
+    tag_dict: dict[str, Tag]={tag.name: tag for tag in tags}
     
-    for tag in tags:
-        tag_dict[tag.name].append(tag)
-    
-    uniqued_tags: list[Tag]=[]
-    for name, tags in tag_dict.items():
-        merged=tags[0]
-        for tag in tags:
-            if tag.id != tag.name: 
-                merged.id=tag.id
-        uniqued_tags.append(merged)
-    
-    return uniqued_tags
+    return [tag_dict[tag_name] for tag_name in selected_tag_names]

--- a/srcs/ai/saving/tag/utils/tag_formatter.py
+++ b/srcs/ai/saving/tag/utils/tag_formatter.py
@@ -1,5 +1,5 @@
 from ai.saving._models import Tag
 
 
-def format_tags(tag_list: list[Tag]) -> str:
-    return ", ".join(f"{tag.name} (id: {tag.id})" for tag in tag_list)
+def format_tags(tags: list[Tag]) -> str:
+    return ", ".join(f"\"{tag.name}\"" for tag in tags)

--- a/srcs/main.py
+++ b/srcs/main.py
@@ -12,8 +12,8 @@ from ai.saving.structure import process_memos, get_structure
 
 app = FastAPI(
     title="Oatnote AI",
-    description="after PR #73, https://github.com/swm-null/null_null/pull/73",
-    version="0.2.22",
+    description="after PR #75, https://github.com/swm-null/null_null/pull/75",
+    version="0.2.24",
 )
 init(app)
     


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호
NULL-440
xtract tag에서 llm이 tag id 처리하지 않게 하기

프롬프트가 전반적으로 짧아지면서 속도와 비용이 개선될 수 있는 작업일 것이라고 추측함

# 🚀 작업 내용

1. 태그 이름을 id처럼 사용할 수 있으므로 아예 모든 과정에서 태그 id를 프롬프트로 안 넘기도록 개선함
2. 기존의 태그와 매우 유사한 태그는 생성되지 않도록 개선함 -> 이건 써보면서 추가적인 피드백 필요

# 💬 리뷰 중점사항

1. 

# 🖼 스크린샷 (선택)
