### PR TITLE
NULL-455-edit-metadata-extractor

### DIFF
--- a/srcs/ai/saving/utils/chains/metadata_extractor_chain.py
+++ b/srcs/ai/saving/utils/chains/metadata_extractor_chain.py
@@ -8,15 +8,15 @@ _parser = StrOutputParser()
 
 _metadata_extractor_chain_prompt=PromptTemplate.from_template(
 """
-I want to categorize these notes later, or create metadata about them so I can find them easily.
+I want to create description about memo so I can find them easily.
 
 Describe what this note is about, or what it contains, as best you can given the information you have.
-Write the metadata in the user's language as well.
+Write the description in the user's language as well.
 
 You might want to include "주민등록번호" in the metadata if it comes in as a string like "928173-2819811", like a Korean social security number,
 If the note is about a series of addresses, we don't know where, but we can add that this is a note about addresses.
 
-User's language: {lang}              
+User's language: {lang}
 Memo's content: {content}
 """
 )

--- a/srcs/main.py
+++ b/srcs/main.py
@@ -14,7 +14,7 @@ from ai.saving.parser import kakao_parser
 
 app = FastAPI(
     title="Oatnote AI",
-    description="after PR #82, https://github.com/swm-null/null_null/pull/81",
+    description="after PR #82, https://github.com/swm-null/null_null/pull/82",
     version="0.2.32",
 )
 init(app)

--- a/srcs/main.py
+++ b/srcs/main.py
@@ -14,8 +14,8 @@ from ai.saving.parser import kakao_parser
 
 app = FastAPI(
     title="Oatnote AI",
-    description="after PR #81, https://github.com/swm-null/null_null/pull/81",
-    version="0.2.31",
+    description="after PR #82, https://github.com/swm-null/null_null/pull/81",
+    version="0.2.32",
 )
 init(app)
     


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 메타데이터 뽑을 때 단어 형태로 형식이 이상하게 뽑혀서 프롬프트에서 이 단어를 태그로 착각하는 대참사가 일어남 그래서 고침

# 💬 리뷰 중점사항

1. 

# 🖼 스크린샷 (선택)
