### PR TITLE
NULL-483-remove-empty-tag

### DIFF
--- a/srcs/ai/saving/structure/processor.py
+++ b/srcs/ai/saving/structure/processor.py
@@ -57,16 +57,16 @@ async def _categorize_new_tags_and_existing_tags(user_id: str, tags: list[Tag]) 
     _, tag_name_to_id=await get_tag_dict(user_id)
     
     new_tags: list[Tag]=[tag for tag in tags if tag.name not in tag_name_to_id]
-    existing_tags: list[Tag]=[
-        Tag(
+    existing_tags: dict[str, Tag]={
+        tag.name: Tag(
             id=tag_name_to_id[tag.name],
             name=tag.name,
             is_new=False,
             connected_memo_id=tag.connected_memo_id
         ) for tag in tags if tag.name in tag_name_to_id
-    ]
+    }
     
-    return new_tags, existing_tags
+    return new_tags, list(existing_tags.values())
 
 def _merge_located_tags_and_new_tags(located_tags: list[Tag], new_tags: list[Tag]) -> list[Tag]:
     tag_name_to_original_tag: dict[str, tuple[str, Optional[int]]]={tag.name: (tag.id, tag.connected_memo_id) for tag in new_tags}

--- a/srcs/ai/saving/structure/utils/locator/chains/get_new_relations_and_tags_chain.py
+++ b/srcs/ai/saving/structure/utils/locator/chains/get_new_relations_and_tags_chain.py
@@ -30,13 +30,13 @@ The directory with the name '@' is the root.
 When the number of '-'s increases, it means you're inside that directory.
 Write the directory's name in the user's language.
 
-Language: {lang}
-New directories: {tags}
-Memos' metadatas: {metadatas}
+Note that the given "New Directories" may be empty. If it is empty, do not create ANYTHING.
 
-Current directories: [
-{directories}
-]
+Language: [ {lang} ]
+New directories: [ {tags} ] 
+Memos' metadatas: [ {metadatas} ]
+
+Current directories: [ {directories} ]
 
 {format}
 """,

--- a/srcs/main.py
+++ b/srcs/main.py
@@ -14,8 +14,8 @@ from ai.saving.parser import kakao_parser
 
 app = FastAPI(
     title="Oatnote AI",
-    description="after PR #87, https://github.com/swm-null/null_null/pull/87",
-    version="0.2.37",
+    description="after PR #89, https://github.com/swm-null/null_null/pull/89",
+    version="0.2.39",
 )
 init(app)
     

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -5,7 +5,7 @@ from main import app
 from models.memo.structures import Res_post_memo_structures
 
 
-body={
+body_with_tag={
     "memos": [
         {
             "content": """
@@ -27,37 +27,64 @@ https://asdf.com/this_is_invalid_link""",
                 "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
             ],
             "tags": [
-            {
-                "id": "a70ab49dda364995ae34a1c76d52d8ef",
-                "name": "부가서비스",
-                "is_new": False
-            },
-            {
-                "id": "836f0c46a0664697b2d0a0cf1526f683",
-                "name": "이동통신 요금제",
-                "is_new": False
-            },
-            {
-                "id": "11111111111111111111111111111111",
-                "name": "이동통신 요금제", # should be ignored
-                "is_new": True
-            },
-            {
-                "id": "22222222222222222222222222222222",
-                "name": "이동통신요금제", # should be ignored
-                "is_new": True
-            },
-            {
-                "id": "ecedd0b9afc34f67aa2ede1029da1f41",
-                "name": "통신 요금제",
-                "is_new": False
-            },
-            {
-                "id": "33333333333333333333333333333333",
-                "name": "T 멤버십",
-                "is_new": False
-            }
+                {
+                    "id": "a70ab49dda364995ae34a1c76d52d8ef",
+                    "name": "부가서비스",
+                    "is_new": False
+                },
+                {
+                    "id": "836f0c46a0664697b2d0a0cf1526f683",
+                    "name": "이동통신 요금제",
+                    "is_new": False
+                },
+                {
+                    "id": "11111111111111111111111111111111",
+                    "name": "이동통신 요금제", # should be ignored
+                    "is_new": True
+                },
+                {
+                    "id": "22222222222222222222222222222222",
+                    "name": "이동통신요금제", # should be ignored
+                    "is_new": True
+                },
+                {
+                    "id": "ecedd0b9afc34f67aa2ede1029da1f41",
+                    "name": "통신 요금제",
+                    "is_new": False
+                },
+                {
+                    "id": "33333333333333333333333333333333",
+                    "name": "T 멤버십",
+                    "is_new": False
+                }
             ]
+        }
+    ],
+    "user_id": "ccc55530-12ed-4a54-b420-025009c0509a"
+}
+
+body_without_tag={
+    "memos": [
+        {
+            "content": """
+5GX 플래티넘(넷플릭스)
+무제한
+테더링/공유 120GB 집/이동전화 무제한, 영상/부가통화 300분 문자 기본 제공
+T 우주 Netflix
+넷플릭스 프리미엄 제공
+T 멤버십
+T 멤버십 VIP 혜택
+스마트기기 이용요금
+스마트기기 2회선 이용요금 무료
+월 125,000원
+선택약정 반영 시 93,705원
+
+https://www.tworld.co.kr/web/product/callplan/NA00008719
+https://asdf.com/this_is_invalid_link""",
+            "image_urls": [
+                "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
+            ],
+            "tags": []
         }
     ],
     "user_id": "ccc55530-12ed-4a54-b420-025009c0509a"
@@ -65,18 +92,27 @@ https://asdf.com/this_is_invalid_link""",
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_structures_using_app():
-    tasks=[asyncio.create_task(send_request_using_app()) for _ in range(3)]
+    tasks=[asyncio.create_task(send_request_and_validate()) for _ in range(3)]
     await asyncio.gather(*tasks)
     
-async def send_request_using_app():
+async def send_request_and_validate():
+    # body with tag
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://localhost:8000") as client:
-        response=await client.post("/memo/structures", json=body)
+        response=await client.post("/memo/structures", json=body_with_tag)
         
     assert response.status_code==200
     res_model=Res_post_memo_structures.model_validate(response.json())
-    validation(res_model)
+    validation_body_with_tag(res_model)
+    
+    # body without tag
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://localhost:8000") as client:
+        response=await client.post("/memo/structures", json=body_without_tag)
+        
+    assert response.status_code==200
+    res_model=Res_post_memo_structures.model_validate(response.json())
+    validation_body_without_tag(res_model)
 
-def validation(res_model: Res_post_memo_structures):
+def validation_body_with_tag(res_model: Res_post_memo_structures):
     UUID_LENGTH=32
     
     # processed_memos
@@ -87,14 +123,6 @@ def validation(res_model: Res_post_memo_structures):
         assert memo.metadata
         if memo.content:
             assert memo.embedding
-    
-    # tags_relations 
-    # for relation in res_model.tags_relations.added:
-    #     assert len(relation.parent_id)==UUID_LENGTH
-    #     assert len(relation.child_id)==UUID_LENGTH
-    # for relation in res_model.tags_relations.deleted:
-    #     assert len(relation.parent_id)==UUID_LENGTH
-    #     assert len(relation.child_id)==UUID_LENGTH
     
     # structures
     for parent, childs in res_model.new_structure.items():
@@ -110,6 +138,6 @@ def validation(res_model: Res_post_memo_structures):
     
     # duplicated tags
     # assert not [tag for tag in res_model.new_tags if tag.name=="이동통신요금제" or tag.name=="이동통신 요금제"]
-    assert not [tag for tag in res_model.new_tags if tag.name=="이동통신 요금제"]
     
-    
+def validation_body_without_tag(res_model: Res_post_memo_structures):
+    assert not [tag for tag in res_model.new_tags]


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 빈 태그가 생겼던 이유: 태그 배치시 배치할 태그가 주어지지 않으면 지 멋대로 이상한 태그를 만듦. 내가 원하는 동작이 아니었기에 이 부분에 대해 태그는 만들어지는데 실제로 메모와 연결짓지는 못 하는 부분이 있었음

2. 원인에 대한 근본적인 해결이 단순한 프롬프트 수정으로는 불가능함. 전에도 비슷한 문제가 몇 번 있었는데 전반적으로 손을 좀 봐야될듯. 일단 땜빵만 쳐놨음

# 💬 리뷰 중점사항

1. 

# 🖼 스크린샷 (선택)
